### PR TITLE
refactor: aide-skill replaces wonskill

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1427,9 +1427,9 @@ fn exec_skill_script(script: &Path, args: &str, working_dir: &Path, env: &[(Stri
 
 /// Execute a skill via wonskill CLI with scoped env
 fn exec_wonskill(skill: &str, args: &str, working_dir: &Path, env: &[(String, String)]) -> Result<(i32, String, String)> {
-    let wonskill = which_wonskill()?;
+    let bin = which_aide_skill()?;
 
-    let mut cmd = std::process::Command::new(&wonskill);
+    let mut cmd = std::process::Command::new(&bin);
     cmd.arg(skill);
     if !args.is_empty() {
         for arg in args.split_whitespace() {
@@ -1442,7 +1442,7 @@ fn exec_wonskill(skill: &str, args: &str, working_dir: &Path, env: &[(String, St
     }
 
     let output = cmd.output()
-        .with_context(|| format!("failed to execute wonskill {} {}", skill, args))?;
+        .with_context(|| format!("failed to execute aide-skill {} {}", skill, args))?;
 
     Ok((
         output.status.code().unwrap_or(-1),
@@ -1451,22 +1451,26 @@ fn exec_wonskill(skill: &str, args: &str, working_dir: &Path, env: &[(String, St
     ))
 }
 
-/// Find wonskill binary
-fn which_wonskill() -> Result<PathBuf> {
-    if let Ok(output) = std::process::Command::new("which").arg("wonskill").output() {
-        if output.status.success() {
-            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !path.is_empty() {
-                return Ok(PathBuf::from(path));
+/// Find aide-skill binary (with wonskill fallback for backward compat)
+fn which_aide_skill() -> Result<PathBuf> {
+    // Try aide-skill first, then wonskill as fallback
+    for name in &["aide-skill", "wonskill"] {
+        if let Ok(output) = std::process::Command::new("which").arg(name).output() {
+            if output.status.success() {
+                let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+                if !path.is_empty() {
+                    return Ok(PathBuf::from(path));
+                }
             }
         }
     }
 
     let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
     let candidates = [
-        format!("{}/.nvm/versions/node/v22.14.0/bin/wonskill", home), // common nvm path
-        format!("{}/bin/wonskill", home),
-        "/usr/local/bin/wonskill".to_string(),
+        format!("{}/.nvm/versions/node/v22.14.0/bin/aide-skill", home),
+        format!("{}/.nvm/versions/node/v22.14.0/bin/wonskill", home),
+        format!("{}/bin/aide-skill", home),
+        "/usr/local/bin/aide-skill".to_string(),
     ];
 
     for candidate in &candidates {
@@ -1476,7 +1480,7 @@ fn which_wonskill() -> Result<PathBuf> {
         }
     }
 
-    bail!("wonskill not found. Install it or add it to PATH.")
+    bail!("aide-skill not found. Install: cd aide-skill && npm link")
 }
 
 // ─── Credential scoping (Docker secrets model) ───


### PR DESCRIPTION
## Summary
- `exec_wonskill()` → `which_aide_skill()`: binary search tries `aide-skill` first, falls back to `wonskill`
- Part of wonskill → aide-skill migration (yiidtw/aide-skill#1)

## Context
aide-skill is now the SSOT for 44 utility skills + vault. wonskill has been deleted from both machines, archive at wonwares/wonskill (private).

🤖 Generated with [Claude Code](https://claude.com/claude-code)