### PR TITLE
feat: GITAW memory commit + inject

### DIFF
--- a/src/agents/instance.rs
+++ b/src/agents/instance.rs
@@ -394,6 +394,110 @@ impl InstanceManager {
         Ok(())
     }
 
+    /// Commit a memory entry to the instance's cognition/memory/ directory.
+    ///
+    /// Each entry is a JSON line appended to `cognition/memory/memory.jsonl`.
+    /// This is the GITAW-compliant memory commit — append-only, auditable.
+    ///
+    /// The entry contains: skill name, args summary, exit code, timestamp.
+    /// This is the minimal memory that satisfies TLA+ CommitMemory.
+    pub fn commit_memory(
+        &self,
+        name: &str,
+        skill: &str,
+        exit_code: i32,
+        output_summary: &str,
+    ) -> Result<()> {
+        let memory_dir = {
+            let inst_dir = self.base_dir.join(name);
+            let cognition_memory = inst_dir.join("cognition").join("memory");
+            if cognition_memory.exists() || inst_dir.join("cognition").exists() {
+                cognition_memory
+            } else {
+                inst_dir.join("memory")
+            }
+        };
+        fs::create_dir_all(&memory_dir)?;
+
+        let memory_file = memory_dir.join("memory.jsonl");
+        let timestamp = Utc::now().to_rfc3339();
+        let reward = if exit_code == 0 { 1 } else { 0 };
+
+        // Truncate output summary to avoid bloat
+        let summary = if output_summary.len() > 500 {
+            &output_summary[..500]
+        } else {
+            output_summary
+        };
+
+        let entry = serde_json::json!({
+            "skill": skill,
+            "exit_code": exit_code,
+            "reward": reward,
+            "summary": summary,
+            "timestamp": timestamp,
+        });
+
+        use std::io::Write;
+        let mut f = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&memory_file)?;
+        f.write_all(entry.to_string().as_bytes())?;
+        f.write_all(b"\n")?;
+
+        Ok(())
+    }
+
+    /// Read all memory entries from an instance's cognition/memory/ directory.
+    ///
+    /// Returns the contents of all `.md` and `.jsonl` files in memory/,
+    /// formatted for injection into an LLM prompt.
+    pub fn read_memory(&self, name: &str) -> Result<String> {
+        let inst_dir = self.base_dir.join(name);
+        let memory_dir = {
+            let cognition_memory = inst_dir.join("cognition").join("memory");
+            if cognition_memory.exists() {
+                cognition_memory
+            } else {
+                inst_dir.join("memory")
+            }
+        };
+
+        if !memory_dir.exists() {
+            return Ok(String::new());
+        }
+
+        let mut parts = Vec::new();
+
+        let mut entries: Vec<_> = fs::read_dir(&memory_dir)?
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                let ext = e.path().extension()
+                    .map(|x| x.to_string_lossy().to_string())
+                    .unwrap_or_default();
+                matches!(ext.as_str(), "md" | "jsonl" | "json" | "txt")
+            })
+            .collect();
+        entries.sort_by_key(|e| e.file_name());
+
+        for entry in entries {
+            let path = entry.path();
+            let filename = entry.file_name().to_string_lossy().to_string();
+            if let Ok(content) = fs::read_to_string(&path) {
+                // Limit each file to avoid context overflow
+                let truncated = if content.len() > 2000 {
+                    format!("{}...(truncated)", &content[..2000])
+                } else {
+                    content
+                };
+                parts.push(format!("### {}\n{}", filename, truncated));
+            }
+        }
+
+        Ok(parts.join("\n\n"))
+    }
+
     /// Read the most recent log entries for an instance.
     ///
     /// Reads from the newest log files first, collecting up to `lines` entries

--- a/src/main.rs
+++ b/src/main.rs
@@ -811,12 +811,18 @@ fn cmd_exec(mgr: &InstanceManager, instance: &str, skill: &str, _interactive: bo
         &format!("exec-result: {} → {} (exit {})", skill, status_msg, exit_code),
     )?;
 
+    // GITAW: auto-commit memory (TLA+ CommitMemory)
+    // Every exec produces a memory entry — append-only, auditable.
+    let summary = if stdout.len() > 500 { &stdout[..500] } else { &stdout };
+    if let Err(e) = mgr.commit_memory(instance, skill, exit_code, summary) {
+        eprintln!("warning: memory commit failed: {}", e);
+    }
+
     if exit_code != 0 {
-        // Docker exec returns the exit code of the executed command
         std::process::exit(exit_code);
     }
 
-    let _ = manifest; // used for future interactive mode
+    let _ = manifest;
     Ok(())
 }
 
@@ -827,8 +833,13 @@ fn cmd_exec_prompt(mgr: &InstanceManager, instance: &str, query: &str) -> Result
 
     let inst_dir = mgr.base_dir().join(instance);
 
-    // Read persona
-    let persona = std::fs::read_to_string(inst_dir.join("persona.md")).unwrap_or_default();
+    // Read persona (try occupation/persona.md first, fall back to persona.md)
+    let persona_path = if inst_dir.join("occupation/persona.md").exists() {
+        inst_dir.join("occupation/persona.md")
+    } else {
+        inst_dir.join("persona.md")
+    };
+    let persona = std::fs::read_to_string(persona_path).unwrap_or_default();
 
     // Read skill catalog from Agentfile
     let skill_info = if let Ok(spec) = AgentfileSpec::load(&inst_dir) {
@@ -837,17 +848,25 @@ fn cmd_exec_prompt(mgr: &InstanceManager, instance: &str, query: &str) -> Result
         String::new()
     };
 
+    // GITAW: Read memory from cognition/memory/ (inject into prompt)
+    let memory = mgr.read_memory(instance).unwrap_or_default();
+    let memory_section = if memory.is_empty() {
+        String::new()
+    } else {
+        format!("\n\n## Memory (from prior executions)\n{}", memory)
+    };
+
     // Compose prompt for Claude
     let prompt = format!(
-        "You are an agent assistant. Given the following agent persona and skills, \
+        "You are an agent assistant. Given the following agent persona, memory, and skills, \
          answer the user's query by deciding which skill(s) to call.\n\n\
          IMPORTANT: Respond ONLY with the skill command to execute, in this exact format:\n\
          EXEC: <skill_name> [args]\n\n\
          The skill_name must be ONLY the skill name (e.g. 'cool', 'mail', 'briefing'), NOT the instance name.\n\
          If you need multiple skills, put each on its own line starting with EXEC:\n\
          If no skill matches, respond with: NONE: <explanation>\n\n\
-         ## Persona\n{}\n\n## Available Skills\n{}\n\n## User Query\n{}",
-        persona, skill_info, query
+         ## Persona\n{}{}\n\n## Available Skills\n{}\n\n## User Query\n{}",
+        persona, memory_section, skill_info, query
     );
 
     // Call claude -p
@@ -914,6 +933,9 @@ fn cmd_exec_prompt(mgr: &InstanceManager, instance: &str, query: &str) -> Result
                         exit_code
                     ),
                 )?;
+                // GITAW: auto-commit memory (TLA+ CommitMemory)
+                let summary = if stdout.len() > 500 { &stdout[..500] } else { &stdout };
+                let _ = mgr.commit_memory(instance, cmd, exit_code, summary);
             } else {
                 println!("skill not found: {}", skill_name);
             }


### PR DESCRIPTION
## Summary

- `cmd_exec`: auto-commit memory entry to `cognition/memory/memory.jsonl` after every skill execution
- `cmd_exec_prompt`: read `cognition/memory/` and inject into LLM prompt

## Why

Without this, agents run 139 GAIA questions and learn nothing. `cognition/memory/` is empty across all instances. TLA+ CommitMemory transition never fires — liveness violated.

## Changes

### instance.rs
- `commit_memory()`: append JSON entry to `cognition/memory/memory.jsonl`
- `read_memory()`: read all files from `cognition/memory/`, format for prompt

### main.rs
- `cmd_exec`: call `commit_memory()` after every skill execution
- `cmd_exec_prompt`: call `read_memory()` and inject `## Memory` section into prompt

## TLA+ alignment

Implements `CommitMemory` from `System.tla`:
- Append-only (jsonl)
- Every exec produces a memory entry (liveness)
- Memory injected into `-p` mode prompt (learning)

## Test plan

- [ ] `aide exec browser.gaia search "test"` → `cognition/memory/memory.jsonl` has entry
- [ ] `aide exec -p browser.gaia "search for test"` → prompt includes memory
- [ ] 28 regression tests in aide-gaia pass

Ref: yiidtw/aide-gaia#71

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>