### PR TITLE
fix: force subscription mode on all claude -p calls

### DIFF
--- a/src/expose/github.rs
+++ b/src/expose/github.rs
@@ -476,6 +476,7 @@ fn exec_agent(
     let output = std::process::Command::new("claude")
         .arg("-p")
         .arg(&prompt)
+        .env("ANTHROPIC_API_KEY", "")
         .output();
 
     let response = match output {

--- a/src/expose/telegram.rs
+++ b/src/expose/telegram.rs
@@ -265,10 +265,11 @@ fn try_claude_prompt(instance: &str, query: &str, inst_dir: &Path) -> Option<Str
         persona, skill_info, query
     );
 
-    // Try claude -p
+    // Try claude -p (force subscription mode — never consume API credits)
     let output = std::process::Command::new("claude")
         .arg("-p")
         .arg(&prompt)
+        .env("ANTHROPIC_API_KEY", "")
         .output()
         .ok()?;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1020,10 +1020,11 @@ fn cmd_exec_prompt(mgr: &InstanceManager, instance: &str, query: &str) -> Result
         persona, skill_info, query
     );
 
-    // Call claude -p
+    // Call claude -p (force subscription mode — never consume API credits)
     let output = std::process::Command::new("claude")
         .arg("-p")
         .arg(&prompt)
+        .env("ANTHROPIC_API_KEY", "")
         .output();
 
     let claude_response = match output {


### PR DESCRIPTION
## Summary
- All 3 `Command::new("claude")` call sites now set `.env("ANTHROPIC_API_KEY", "")` to force subscription mode
- Prevents agents from accidentally consuming API credits when `ANTHROPIC_API_KEY` exists in environment

## Affected files
- `src/main.rs` — aide exec semantic dispatch
- `src/expose/telegram.rs` — telegram gateway LLM fallback
- `src/expose/github.rs` — github issue gateway LLM dispatch

## Root cause
formace-00 上 agent session 報 "Credit balance is too low" — 因為環境裡有 API key，claude CLI 走了 API mode 而非 subscription。

## Test plan
- [x] `cargo check` passes
- [ ] Deploy to formace-00, verify no API credit consumption

Fixes yiidtw/aide-private#2

🤖 Generated with [Claude Code](https://claude.com/claude-code)